### PR TITLE
build-env VM: added error detection in build.sh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,9 +60,7 @@ KairosDB frontend, i.e. for manually query of metrics:
 Issues
 ------
 
-* Every LDAP user has admin role (because I could not get the OpenLDAP "memberOf" overlay to work)
-
-* If single containers do not start up ssh into the vagrant box and run the start.sh script again manually or use the start-services.sh script to restart single components. Later one takes parameters like controller or worker.
+* If single containers do not start up ssh into the vagrant box and run the `start.sh` script again manually or use the `start-services.sh` script to restart single components. Later one takes parameters like `controller` or `worker`.
 
 Install the Command Line Interface
 ==================================

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ KairosDB frontend, i.e. for manually query of metrics:
 Issues
 ------
 
-* every LDAP user has admin role (because I could not get the OpenLDAP "memberOf" overlay to work
+* Every LDAP user has admin role (because I could not get the OpenLDAP "memberOf" overlay to work)
 
 * If single containers do not start up ssh into the vagrant box and run the start.sh script again manually or use the start-services.sh script to restart single components. Later one takes parameters like controller or worker.
 

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ KairosDB frontend, i.e. for manually query of metrics:
 Issues
 ------
 
-* If single containers do not start up ssh into the vagrant box and run the `start.sh` script again manually or use the `start-services.sh` script to restart single components. Later one takes parameters like `controller` or `worker`.
+* If single containers do not start up ssh into the vagrant box and run the ``start.sh`` script again manually or use the ``start-services.sh`` script to restart single components. Later one takes parameters like ``controller`` or ``worker``.
 
 Install the Command Line Interface
 ==================================

--- a/build-env/Vagrantfile
+++ b/build-env/Vagrantfile
@@ -10,16 +10,24 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.hostname = "zmon"
 
-    # ZMON Controller
+    # Controller
     config.vm.network :forwarded_port, guest: 8080, host: 38080
+    config.vm.network :forwarded_port, guest: 8443, host: 38443
+
     # KairosDB
     config.vm.network :forwarded_port, guest: 8084, host: 38084
 
     # Scheduler
     config.vm.network :forwarded_port, guest: 8085, host: 38085
 
+    # Redis
+    config.vm.network :forwarded_port, guest: 6379, host: 38086
+
     # KairosDB
     config.vm.network :forwarded_port, guest: 8083, host: 38083
+
+    # PostgreSQL
+    config.vm.network :forwarded_port, guest: 5432, host: 38088
 
     config.vm.provider "virtualbox" do |vb|
         vb.name = "ZMON-BUILD"

--- a/build-env/build.sh
+++ b/build-env/build.sh
@@ -17,6 +17,14 @@ function progress {
     echo -e "${COLOR_PROGRESS}$1..${COLOR_RESET}"
 }
 
+function clone_or_pull {
+    if [ -d $1 ]; then
+        cd $1; git pull; cd ..
+    else
+        git clone https://github.com/zalando/$1.git
+    fi
+}
+
 echo "  ________  __  ____  _   _ "
 echo " |___  /  \/  |/ __ \| \ | |"
 echo "    / /| \  / | |  | |  \| |"
@@ -33,34 +41,35 @@ JAVA_VERSION=$(java -version 2>&1 | head -n 1 | grep -o '1\.[78]')
 PYTHON_VERSION=$(python --version 2>&1 | grep -o '2\.7')
 [ "v$PYTHON_VERSION" = "v2.7" ] || fail "Python 2.7 is required"
 
-cd /home/vagrant
+DIR=${2:-"/home/vagrant"}
+cd $DIR || fail "${DIR} does not exist"
 
 if [ "b$1" = "b" ] || [ "b$1" = "bcontroller" ] ; then
     progress 'Building Controller'
-    git clone https://github.com/zalando/zmon-controller.git
-    (cd zmon-controller && ./mvnw clean package && docker build -t zmon-controller .)
+    clone_or_pull zmon-controller
+    (cd zmon-controller && ./mvnw clean package && scm-source -f target/scm-source.json && docker build -t zmon-controller .) || fail "Error building Controller"
 fi
 
 if [ "b$1" = "b" ] || [ "b$1" = "beventlog-service" ] ; then
     progress 'Building Eventlog Service'
-    git clone https://github.com/zalando/zmon-eventlog-service.git
-    (cd zmon-eventlog-service && ./mvnw clean package && docker build -t zmon-eventlog-service .)
+    clone_or_pull zmon-eventlog-service
+    (cd zmon-eventlog-service && ./mvnw clean package && scm-source -f target/scm-source.json && docker build -t zmon-eventlog-service .) || fail "Error building Eventlog Service"
 fi
 
 if [ "b$1" = "b" ] || [ "b$1" = "bdata-service" ] ; then
     progress 'Building Data Service'
-    git clone https://github.com/zalando/zmon-data-service.git
-    (cd zmon-data-service && ./mvnw clean package && docker build -t zmon-data-service .)
+    clone_or_pull zmon-data-service
+    (cd zmon-data-service && ./mvnw clean package && docker build -t zmon-data-service .) || fail "Error building Data Service"
 fi
 
 if [ "b$1" = "b" ] || [ "b$1" = "bscheduler" ] ; then
     progress 'Building Scheduler'
-    git clone https://github.com/zalando/zmon-scheduler-ng.git zmon-scheduler
-    (cd zmon-scheduler && ./mvnw clean package && docker build -t zmon-scheduler .)
+    clone_or_pull zmon-scheduler
+    (cd zmon-scheduler && ./mvnw clean package && scm-source && docker build -t zmon-scheduler .) || fail "Error building Scheduler"
 fi
 
 if [ "b$1" = "b" ] || [ "b$1" = "bworker" ] ; then
     progress 'Building Worker'
-    git clone https://github.com/zalando/zmon-worker.git
-    (cd zmon-worker && docker build -t zmon-worker .)
+    clone_or_pull zmon-worker
+    (cd zmon-worker && scm-source && docker build -t zmon-worker .) || fail "Error building Worker"
 fi


### PR DESCRIPTION
I freshly cloned all zmon projects and wanted to run them in the `build-env` vm. In order to build the docker containers I had to make some adaptions to the `build.sh`, which I included here.